### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*.*.*' # Matches version tags like 1.0.0, 2.1.3, etc.
 
+permissions:
+  contents: read
+
 jobs:
   create_nuget:
     name: Create NuGet
@@ -39,6 +42,9 @@ jobs:
   deploy:
     name: Deploy NuGet
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     # A ready artifact is required before publishing
     # The job waits for the create_nuget job to complete
     needs: create_nuget


### PR DESCRIPTION
Potential fix for [https://github.com/s-laugh/GCDS.NetTemplate/security/code-scanning/2](https://github.com/s-laugh/GCDS.NetTemplate/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. At the root level, we will set `contents: read` as the default permission for all jobs. For the `Deploy NuGet` job, we will override the permissions to include `packages: write` since it requires write access to publish the NuGet package. This ensures that the workflow has only the permissions it needs and no more.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
