### PR TITLE
Adds breadcrumbs and a new AppTop component for InternalApp

### DIFF
--- a/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
+++ b/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
@@ -26,6 +26,35 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
             template.Header.Banner = new CustomPartial() { ViewName = "Banner", Model = new Banner() { Text = "Jokes on You!" } };
             template.Header.SkipToNav = new SkipTo() { Link = new Link { Text = "Skip to nav content", Href = "#nav" } };
 
+            template.Header.Menu = new TopNav
+            {
+                Label = "Top Nav",
+                Alignment = TopNav.AlignmentType.left,
+                Links =
+               [
+                   new Link { Text = "Link 1", Href = "#" },
+                    new NavGroup { Label = "Group 1",
+                        Links =
+                        [
+                            new Link { Text = "Link 1.1", Href = "#" },
+                            new Link { Text = "Link 1.2", Href = "#" }
+                        ]
+                    },
+                    new Link { Text = "Link 2", Href = "#" }
+               ],
+                //StyleOverride = "background-color: #e1e4e7;"
+            };
+
+            template.Header.Breadcrumb = new Breadcrumbs
+            {
+                Items = [
+                        new Link
+                        {
+                            Text = "Home"
+                        }
+                        ]
+            };
+
             return View();
         }
 
@@ -33,15 +62,21 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
         public IActionResult Internal()
         {
             var template = ViewData.GetTemplate<InternalAppTemplate>();
-                        
+
+            template.Header = new InternalAppHeader("My Application");
+            template.Header = new InternalAppHeader(new Link { Text = "Home", Href = "#" });
+            // OR
             template.Header = new InternalAppHeader
             {
-                SiteTitle = new Link
+                AppHeaderTop = new AppHeaderTop
                 {
-                    Text = "My Application",
-                    Href = Url.Action("Index")
+                    SiteTitle = new Link
+                    {
+                        Text = "My Application",
+                        Href = Url.Action("Index")
+                    },
+                    StyleOverride = "border-bottom: 4px solid #243851"
                 },
-                StyleOverride = "border-bottom: 4px solid #243851",
                 Menu = new TopNav
                 {
                     Label = "Top Nav",
@@ -58,7 +93,17 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
                     },
                     new Link { Text = "Link 2", Href = "#" }
                ],
-                    StyleOverride = "background-color: #e1e4e7;"
+                    //StyleOverride = "background-color: #e1e4e7;"
+                },
+                Breadcrumbs = new Breadcrumbs
+                {
+                    Items = [
+                        new Link
+                        {
+                            Text = "Home",
+                            Href = Url.Action("Index")
+                        },
+                        ]
                 }
             };
             template.Footer.StyleOverride = "border-top: 4px solid #243851; background: #f8f8f8;";

--- a/GCDS.NetTemplate/Components/Custom/AppHeaderTop.cs
+++ b/GCDS.NetTemplate/Components/Custom/AppHeaderTop.cs
@@ -1,0 +1,23 @@
+﻿using GCDS.NetTemplate.Components.Gcds;
+
+namespace GCDS.NetTemplate.Components.Custom
+{
+    public class AppHeaderTop
+    {
+        /// <summary>
+        /// Language toogle link
+        /// Will be set inside the layout from the Template
+        /// </summary>
+        public LangToggle LanguageToggle { get; set; } = new LangToggle() { Href = string.Empty };
+
+        /// <summary>
+        /// Sets the title of the site (or application)
+        /// </summary>
+        public required Link SiteTitle { get; set; }
+
+        /// <summary>
+        /// Enables limited custom styling for the header
+        /// </summary>
+        public string? StyleOverride { get; set; }
+    }
+}

--- a/GCDS.NetTemplate/Components/Custom/InternalAppHeader.cs
+++ b/GCDS.NetTemplate/Components/Custom/InternalAppHeader.cs
@@ -1,20 +1,30 @@
 ﻿using GCDS.NetTemplate.Components.Gcds;
 using GCDS.NetTemplate.Utils;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GCDS.NetTemplate.Components.Custom
 {
     public class InternalAppHeader
     {
-        /// <summary>
-        /// Language toogle link
-        /// Will be set inside the layout from the Template
-        /// </summary>
-        public LangToggle LanguageToggle { get; set; } = new LangToggle() { Href = string.Empty };
+        public InternalAppHeader() { }
 
-        /// <summary>
-        /// Sets the title of the site (or application)
-        /// </summary>
-        public required Link SiteTitle { get; set; }
+        [SetsRequiredMembers]
+        public InternalAppHeader(string siteTitleText)
+        {
+            AppHeaderTop = new AppHeaderTop
+            {
+                SiteTitle = new Link
+                {
+                    Text = siteTitleText
+                }
+            };
+        }
+
+        [SetsRequiredMembers]
+        public InternalAppHeader(Link siteTitle)
+        {
+            AppHeaderTop = new AppHeaderTop { SiteTitle = siteTitle };
+        }
 
         /// <summary>
         /// Provides information for the skip to content link
@@ -32,15 +42,18 @@ namespace GCDS.NetTemplate.Components.Custom
         };
 
         /// <summary>
+        /// Provides information for the top section of the header
+        /// </summary>
+        public required AppHeaderTop AppHeaderTop { get; set; }
+
+        /// <summary>
         /// Enables implementing a Menu with the TopNav component
         /// </summary>
         public TopNav? Menu { get; set; }
 
         /// <summary>
-        /// Enables limited custom styling for the header
+        /// Enables implementing a Breadcrumbs component
         /// </summary>
-        public string? StyleOverride { get; set; }
-
-
+        public Breadcrumbs? Breadcrumbs { get; set; }
     }
 }

--- a/GCDS.NetTemplate/Templates/Custom/InternalAppTemplate.cs
+++ b/GCDS.NetTemplate/Templates/Custom/InternalAppTemplate.cs
@@ -7,10 +7,20 @@ namespace GCDS.NetTemplate.Templates.Custom
 {
     public class InternalAppTemplate(TemplateSettings settings) : Template(settings), ITemplate
     {
+        /// <summary>
+        /// Loading all the configurations for the header component
+        /// </summary>
         public required InternalAppHeader Header { get; set; }
 
+        /// <summary>
+        /// Loading all the configurations for the footer component
+        /// </summary>
         public Footer Footer { get; set; } = new Footer();
 
+        /// <summary>
+        /// Apply a last modified date or version number
+        /// Will atomatically grab the version from your dll.
+        /// </summary>
         public DateModified DateModified { get; set; } = new DateModified()
         {
             // get the version number of the project that started (impemented this package) and trim any trailing zeros from the version

--- a/GCDS.NetTemplate/Templates/Gcds/BasicTemplate.cs
+++ b/GCDS.NetTemplate/Templates/Gcds/BasicTemplate.cs
@@ -22,9 +22,12 @@ namespace GCDS.NetTemplate.Templates.Gcds
             Display = Footer.DisplayType.full
         };
 
+        /// <summary>
+        /// Apply a last modified date or version number
+        /// Will atomatically grab the last date your dll was compiled.
+        /// </summary>
         public DateModified DateModified { get; set; } = new DateModified()
         {
-
             // get the date changed of the project that started (impemented this package)
             Text = File.GetLastWriteTime(Assembly.GetEntryAssembly()?.Location ?? string.Empty).ToString("MMMM dd, yyyy")
         };

--- a/GCDS.NetTemplate/Views/Shared/Custom/AppHeaderTop.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/Custom/AppHeaderTop.cshtml
@@ -1,0 +1,24 @@
+﻿@using GCDS.NetTemplate.Components.Custom
+@model AppHeaderTop
+
+
+<gcds-container size="xl"
+				centered
+				main-container
+				style="@Model.StyleOverride">
+	<gcds-grid columns="2fr 1fr"
+			   align-items="center"
+			   place-content="space-between">
+
+		<gcds-nav-link href="@Model.SiteTitle.Href">
+			@Model.SiteTitle.Text
+		</gcds-nav-link>
+
+		@{
+			Model.LanguageToggle.StyleOverride += "text-align:end";
+		}
+		@await Html.PartialAsync("Gcds/LangToggle", Model.LanguageToggle)
+
+	</gcds-grid>
+
+</gcds-container>

--- a/GCDS.NetTemplate/Views/Shared/Custom/InternalAppHeader.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/Custom/InternalAppHeader.cshtml
@@ -1,31 +1,24 @@
 ﻿@using GCDS.NetTemplate.Components.Custom
 @model InternalAppHeader
 
-<header style="margin: var(--gcds-header-margin) !important">
+<header style="margin: var(--gcds-header-margin) !important;">
+
 	@await Html.PartialAsync("Custom/SkipTo", Model.SkipToMainContent)
 
-	<gcds-container size="xl"
-	centered
-	main-container
-	style="@Model.StyleOverride">
-		<gcds-grid columns="2fr 1fr"
-		align-items="center"
-		place-content="space-between">
-
-			<gcds-nav-link href="@Model.SiteTitle.Href">
-				@Model.SiteTitle.Text
-			</gcds-nav-link>
-
-			@{
-				Model.LanguageToggle.StyleOverride = "text-align:end";
-			}
-			@await Html.PartialAsync("Gcds/LangToggle", Model.LanguageToggle)
-
-		</gcds-grid>
-	</gcds-container>
+	@await Html.PartialAsync("Custom/AppHeaderTop", Model.AppHeaderTop)
 
 	@if (Model.Menu != null)
 	{
 		@await Html.PartialAsync("Gcds/TopNav", Model.Menu)
 	}
+
+	@if (Model.Breadcrumbs != null)
+	{
+		<gcds-container size="xl"
+						centered
+						main-container>
+			@await Html.PartialAsync("Gcds/Breadcrumbs", Model.Breadcrumbs)
+		</gcds-container>
+	}
+
 </header>

--- a/GCDS.NetTemplate/Views/Shared/_Layout.InternalApp.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/_Layout.InternalApp.cshtml
@@ -22,7 +22,7 @@
 <body>
 	@{
 		ArgumentNullException.ThrowIfNull(template.Header, "Header must be set when using this template.");
-		template.Header.LanguageToggle.Href = template.LanguageToggleHref;
+		template.Header.AppHeaderTop.LanguageToggle.Href = template.LanguageToggleHref;
 	}
 	@await Html.PartialAsync("Custom/InternalAppHeader", template.Header)
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ _Note: Most GCDS compontes can be used natively within the view so are not buit 
     - [Theme and topic menu (`TopicMenu`)](https://design-system.alpha.canada.ca/en/components/theme-and-topic-menu/)
     - [Top navigation (`TopNav`)](https://design-system.alpha.canada.ca/en/components/top-navigation/)
   - Custom components
-    - InternalAppHeader: Custom Header for the `InternalAppTemplate`
-    - SiteTitle: Custom title for the `InternalAppTemplate`
+    - AppHeaderTop: A top section for the `InternalAppHeader` 
+    - InternalAppHeader: Header for the `InternalAppTemplate`
+    - SiteTitle: Title (link) for the `AppHeaderTop`
     - SkipTo: Custom hidden link to skip to a section, used in the `InternalAppTemplate`
   - Other Partials
     - Head: Implements `TemplateSettings` for a `<head>` section

--- a/README.md
+++ b/README.md
@@ -72,19 +72,33 @@ This is how you can edit the breadcrumbs, menu, footer links, or override featur
 var template = ViewData.GetTemplate<InternalAppTemplate>();
 ```
 
-#### Using `InternalAppTemplate`
-
-This template will require you to manually create the `Header` with the required `SiteTitle` link.
+It's a good idea to set some basic properties specific to your useage, such as:
 
 ```csharp
-template.Header = new InternalAppHeader()
+template.PageTitle = "Text for the browser tab";
+```
+
+
+#### Using `InternalAppTemplate`
+
+This template will require you to manually create the `Header` as it requires you to set `SiteTitle` link text. The object initializer can be used or use the convient constructors.
+
+```csharp
+template.Header = new InternalAppHeader("My Application");
+// OR
+template.Header = new InternalAppHeader(new Link { Text = "Home", Href = "#" });
+// OR
+template.Header = new InternalAppHeader
+{
+    AppHeaderTop = new AppHeaderTop
     {
-        SiteTitle = new Link()
+        SiteTitle = new Link
         {
             Text = "My Application",
-            Href = Url.Page("Index")
-        },
-    };
+            Href = Url.Action("Index")
+        }
+    }
+}
 ```
 
 _Reminder: Be sure to use the `_Layout.InternalApp` when using this template._


### PR DESCRIPTION
- Adds the GCDS `Breadcrumb` component to the custom `InternalAppHeader`
- Moves `LanguageToggle`, `SiteTitle`, and `StyleOverride` from the `InternalAppHeader` to a new custom component `AppHeaderTop`
- Adds constructors to the `InternalAppHeader` assisting in the initialization of required properties (`SiteTitle.Text`)
- Improves documentation of the use of properties

completes #18 