### PR TITLE
Adding separation and sub components for GcdsTopNav

### DIFF
--- a/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
+++ b/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
@@ -41,15 +41,15 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
                 Alignment = GcdsTopNav.AlignmentType.left,
                 Links =
                [
-                   new GcdsLink { Text = "Link 1", Href = "#" },
+                   new GcdsNavLink { Text = "Link 1", Href = "#" },
                     new GcdsNavGroup { Label = "Group 1",
                         Links =
                         [
-                            new GcdsLink { Text = "Link 1.1", Href = "#" },
-                            new GcdsLink { Text = "Link 1.2", Href = "#" }
+                            new GcdsNavLink { Text = "Link 1.1", Href = "#" },
+                            new GcdsNavLink { Text = "Link 1.2", Href = "#" }
                         ]
                     },
-                    new GcdsLink { Text = "Link 2", Href = "#" }
+                    new GcdsNavLink { Text = "Link 2", Href = "#" }
                ],
                 //StyleOverride = "background-color: #e1e4e7;"
             };
@@ -59,7 +59,8 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
                 Items = [
                         new GcdsLink
                         {
-                            Text = "Home"
+                            Text = "Home",
+                            Href ="#"
                         }
                         ]
             };
@@ -92,15 +93,15 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
                     Alignment = GcdsTopNav.AlignmentType.left,
                     Links =
                [
-                   new GcdsLink { Text = "Link 1", Href = "#" },
+                   new GcdsNavLink { Text = "Link 1", Href = "#" },
                     new GcdsNavGroup { Label = "Group 1",
                         Links =
                         [
-                            new GcdsLink { Text = "Link 1.1", Href = "#" },
-                            new GcdsLink { Text = "Link 1.2", Href = "#" }
+                            new GcdsNavLink { Text = "Link 1.1", Href = "#" },
+                            new GcdsNavLink { Text = "Link 1.2", Href = "#" }
                         ]
                     },
-                    new GcdsLink { Text = "Link 2", Href = "#" }
+                    new GcdsNavLink { Text = "Link 2", Href = "#" }
                ],
                     //StyleOverride = "background-color: #e1e4e7;"
                 },

--- a/GCDS.NetTemplate/Components/CommonLinkBase.cs
+++ b/GCDS.NetTemplate/Components/CommonLinkBase.cs
@@ -1,0 +1,8 @@
+﻿namespace GCDS.NetTemplate.Components
+{
+    public class CommonLinkBase : CommonProps
+    {
+        public required string Href { get; set; }
+        public required string Text { get; set; }
+    }
+}

--- a/GCDS.NetTemplate/Components/GcdsLink.cs
+++ b/GCDS.NetTemplate/Components/GcdsLink.cs
@@ -4,7 +4,7 @@
     /// Class holder for the link properties as defined in the GCDS template
     /// https://design-system.alpha.canada.ca/en/components/link/
     /// </summary>
-    public class GcdsLink : CommonProps, ISlotHeaderNavLink
+    public class GcdsLink : CommonLinkBase
     {
         public enum DisplayType
         {
@@ -22,9 +22,6 @@
             @default,
             light,
         }
-
-        public string? Href { get; set; }
-        public required string Text { get; set; }
 
         public DisplayType Display { get; set; } = DisplayType.inline;
         public string? Download { get; set; }

--- a/GCDS.NetTemplate/Components/GcdsNavGroup.cs
+++ b/GCDS.NetTemplate/Components/GcdsNavGroup.cs
@@ -6,13 +6,34 @@
     public class GcdsNavGroup : ISlotHeaderNavLink
     {
         /// <summary>
-        /// This is the header, clickable text for the group to open
+        /// Label for the nav group menu
         /// </summary>
         public required string Label { get; set; }
+
+        private string? openTrigger;
+        /// <summary>
+        /// Label for the collapsed button trigger.
+        /// Defaults to Label
+        /// </summary>
+        public string OpenTrigger
+        {
+            get => openTrigger ?? Label;
+            set { openTrigger = value; }
+        }
+
+        /// <summary>
+        /// Label for the expanded button trigger
+        /// </summary>
+        public string? CloseTrigger { get; set; }
+
+        /// <summary>
+        /// Has the nav group been expanded
+        /// </summary>
+        public bool Open { get; set; }
 
         /// <summary>
         /// links that will be shown under the header
         /// </summary>
-        public required IEnumerable<GcdsLink> Links { get; set; }
+        public required IEnumerable<GcdsNavLink> Links { get; set; }
     }
 }

--- a/GCDS.NetTemplate/Components/GcdsNavLink.cs
+++ b/GCDS.NetTemplate/Components/GcdsNavLink.cs
@@ -1,0 +1,7 @@
+﻿namespace GCDS.NetTemplate.Components
+{
+    public class GcdsNavLink : CommonLinkBase, ISlotHeaderNavLink
+    {
+        public bool Current { get; set; } 
+    }
+}

--- a/GCDS.NetTemplate/Components/GcdsTopNav.cs
+++ b/GCDS.NetTemplate/Components/GcdsTopNav.cs
@@ -26,7 +26,7 @@
         /// <summary>
         /// Customize the content for the home link.
         /// </summary>
-        public GcdsLink? Home { get; set; }
+        public GcdsNavLink? Home { get; set; }
 
         /// <summary>
         /// Links or NavGroups (dropdown of links) to be displayed in the TopNav

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsNavGroup.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsNavGroup.cshtml
@@ -1,0 +1,11 @@
+﻿@model GCDS.NetTemplate.Components.GcdsNavGroup
+
+<gcds-nav-group menu-label="@Model.Label"
+				open-trigger="@Model.OpenTrigger"
+				close-trigger="@Model.CloseTrigger"
+				open="@Model.Open">
+	@foreach (var subItem in Model.Links)
+	{
+		@await Html.PartialAsync("GcdsNavLink.cshtml", subItem)
+	}
+</gcds-nav-group>

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsNavLink.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsNavLink.cshtml
@@ -1,7 +1,7 @@
-﻿@using GCDS.NetTemplate.Components
+﻿@model GCDS.NetTemplate.Components.GcdsNavLink
 
-@model GcdsLink
-
-<gcds-nav-link href="@Model.Href" slot="@Model.Slot">
+<gcds-nav-link href="@Model.Href"
+			   slot="@Model.Slot"
+			   current="@Model.Current">
 	@Model.Text
 </gcds-nav-link>

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsTopNav.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsTopNav.cshtml
@@ -3,14 +3,15 @@
 @model GcdsTopNav
 
 <gcds-top-nav slot="@Model.Slot"
-label="@Model.Label"
-alignment="@Model.Alignment"
-lang="@Model.Lang"
-style="@Model.StyleOverride">
+			  label="@Model.Label"
+			  alignment="@Model.Alignment"
+			  lang="@Model.Lang"
+			  style="@Model.StyleOverride">
 
 	@if (Model.Home != null)
 	{
 		Model.Home.Slot = "home";
+		<!--Home Slot-->
 		@await Html.PartialAsync("GcdsNavLink.cshtml", Model.Home)
 	}
 
@@ -18,16 +19,13 @@ style="@Model.StyleOverride">
 	{
 		switch (item)
 		{
-			case GcdsLink link:
+			case GcdsNavLink link:
+				<!--link-->
 				@await Html.PartialAsync("GcdsNavLink.cshtml", link)
 				break;
 			case GcdsNavGroup group:
-				<gcds-nav-group open-trigger="@group.Label" menu-label="@group.Label">
-					@foreach (var subItem in ((GcdsNavGroup)item).Links)
-					{
-						@await Html.PartialAsync("GcdsNavLink.cshtml", subItem)
-					}
-				</gcds-nav-group>
+				<!--group-->
+				@await Html.PartialAsync("GcdsNavGroup.cshtml", group)
 				break;
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ _Note: Most GCDS compontes can be used natively within the view so are not buit 
     - [`GcdsHeader`](https://design-system.alpha.canada.ca/en/components/header/)
     - [`GcdsLangToggle` (Language Toogle)](https://design-system.alpha.canada.ca/en/components/language-toggle/)
     - [`GcdsLink`](https://design-system.alpha.canada.ca/en/components/link/)
-    - _GcdsNavGroup_: A sub-component used in the `GcdsTopNav`
+    - [`GcdsNavGroup`](https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-nav-group): A sub-component used in the `GcdsTopNav`
+    - [`GcdsNavLink`](https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-nav-link): A sub-component used in `GcdsTopNav` and `GcdsNavGroup`
     - [`GcdsSearch`](https://design-system.alpha.canada.ca/en/components/search/)
     - [`GcdsSignature`](https://design-system.alpha.canada.ca/en/components/signature/)
     - [`GcdsTopicMenu` (Theme and topic menu)](https://design-system.alpha.canada.ca/en/components/theme-and-topic-menu/)


### PR DESCRIPTION
- Properly establishes the GcdsNavGroup as a component
- Add the GcdsNavLink component (replacing GcdsLink in some places)
- Brings common link props to CommonLinkBase and makes Href required

Resolves #29 