### PR TITLE
Common layout

### DIFF
--- a/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
+++ b/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
@@ -73,11 +73,9 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
         {
             var template = ViewData.GetTemplate<InternalApp>();
 
-            template.Inizialize("My Application Title", "Internal Page Name");
+            template.Inizialize("My Application Title");
             // OR
-            template.Inizialize(
-                new ExtSiteTitle { Text = "Home", Href = "#" }, 
-                "Internal Page Name")
+            template.Inizialize(new ExtSiteTitle { Text = "Home", Href = "#" })
                 .HeadElements.AddMeta("name", "content");
             // OR
             template.Header = new ExtAppHeader

--- a/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
+++ b/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
@@ -73,13 +73,18 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
         {
             var template = ViewData.GetTemplate<InternalApp>();
 
-            template.Header = new ExtAppHeader("My Application");
-            template.Header = new ExtAppHeader(new ExtSiteTitle { Text = "Home", Href = "#" });
+            template.Inizialize("My Application Title", "Internal Page Name");
+            // OR
+            template.Inizialize(
+                new ExtSiteTitle { Text = "Home", Href = "#" }, 
+                "Internal Page Name")
+                .HeadElements.AddMeta("name", "content");
             // OR
             template.Header = new ExtAppHeader
             {
                 AppHeaderTop = new ExtAppHeaderTop
                 {
+                    LanguageToggle = new GcdsLangToggle { Href = template.LangToggleHref },
                     SiteTitle = new ExtSiteTitle
                     {
                         Text = "My Very Long Application Title That fills the whole header",

--- a/GCDS.NetTemplate.Razor.Sanity/Pages/Internal.cshtml.cs
+++ b/GCDS.NetTemplate.Razor.Sanity/Pages/Internal.cshtml.cs
@@ -24,8 +24,7 @@ namespace GCDS.NetTemplate.Razor.Sanity.Pages
                 new ExtSiteTitle { 
                     Text = "My Application",
                     Href = Url.Page("Index")
-                },
-                "Internal Page Name"
+                }
             );
         }
     }

--- a/GCDS.NetTemplate.Razor.Sanity/Pages/Internal.cshtml.cs
+++ b/GCDS.NetTemplate.Razor.Sanity/Pages/Internal.cshtml.cs
@@ -20,11 +20,12 @@ namespace GCDS.NetTemplate.Razor.Sanity.Pages
         public void OnGet()
         {
             var template = ViewData.GetTemplate<InternalApp>();
-            template.Header = new ExtAppHeader(
+            template.Inizialize(
                 new ExtSiteTitle { 
                     Text = "My Application",
                     Href = Url.Page("Index")
-                }
+                },
+                "Internal Page Name"
             );
         }
     }

--- a/GCDS.NetTemplate/Components/ExtAppHeader.cs
+++ b/GCDS.NetTemplate/Components/ExtAppHeader.cs
@@ -1,30 +1,9 @@
 ﻿using GCDS.NetTemplate.Core;
-using System.Diagnostics.CodeAnalysis;
 
 namespace GCDS.NetTemplate.Components
 {
     public class ExtAppHeader
     {
-        public ExtAppHeader() { }
-
-        [SetsRequiredMembers]
-        public ExtAppHeader(string siteTitleText)
-        {
-            AppHeaderTop = new ExtAppHeaderTop
-            {
-                SiteTitle = new ExtSiteTitle
-                {
-                    Text = siteTitleText
-                }
-            };
-        }
-
-        [SetsRequiredMembers]
-        public ExtAppHeader(ExtSiteTitle siteTitle)
-        {
-            AppHeaderTop = new ExtAppHeaderTop { SiteTitle = siteTitle };
-        }
-
         /// <summary>
         /// Provides information for the skip to content link
         /// Automatically set for the current language

--- a/GCDS.NetTemplate/Components/ExtAppHeaderTop.cs
+++ b/GCDS.NetTemplate/Components/ExtAppHeaderTop.cs
@@ -6,7 +6,7 @@
         /// Language toogle link
         /// Will be set inside the layout from the Template
         /// </summary>
-        public GcdsLangToggle LanguageToggle { get; set; } = new GcdsLangToggle() { Href = string.Empty };
+        public required GcdsLangToggle LanguageToggle { get; set; }
 
         /// <summary>
         /// Sets the title of the site (or application)

--- a/GCDS.NetTemplate/Components/GcdsHeader.cs
+++ b/GCDS.NetTemplate/Components/GcdsHeader.cs
@@ -14,13 +14,11 @@
 
         /// <summary>
         /// Language toogle link
-        /// Will be set inside the layout from the Template
         /// </summary>
         public string? LangHref { get; set; }
 
         /// <summary>
         /// Skip to main content href
-        /// Will be set inside the layout based on a pre-defined const.
         /// </summary>
         public string? SkipToHref { get; set; }
 

--- a/GCDS.NetTemplate/Core/CommonConstants.cs
+++ b/GCDS.NetTemplate/Core/CommonConstants.cs
@@ -15,5 +15,7 @@
         public const string SKIP_TO_AIRIA_LABEL_FR = "Passer au";
         public const string SKIP_TO_TEXT_EN = "Skip to main content";
         public const string SKIP_TO_TEXT_FR = "Passer au contenu principal";
+
+        public const string ERRMSG_LOAD_TEMPLATE = "Must call Add[Mvc/Razor]TemplateServices in Program.cs, and verify the template is loaded to the ViewData to use this layout.";
     }
 }

--- a/GCDS.NetTemplate/Core/CultureManager.cs
+++ b/GCDS.NetTemplate/Core/CultureManager.cs
@@ -18,7 +18,7 @@ namespace GCDS.NetTemplate.Core
 
         public static string BuildLanguageToggleHref(NameValueCollection nameValues)
         {
-            if (nameValues == null) throw new ArgumentNullException(nameof(nameValues));
+            ArgumentNullException.ThrowIfNull(nameValues);
 
             nameValues.Set(CommonConstants.QUERYSTRING_CULTURE_KEY,
                 Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName.StartsWith(CommonConstants.ENGLISH_CULTURE_TWO_LETTER,

--- a/GCDS.NetTemplate/Core/CultureManager.cs
+++ b/GCDS.NetTemplate/Core/CultureManager.cs
@@ -18,7 +18,7 @@ namespace GCDS.NetTemplate.Core
 
         public static string BuildLanguageToggleHref(NameValueCollection nameValues)
         {
-            ArgumentNullException.ThrowIfNull(nameValues);
+            if (nameValues == null) throw new ArgumentNullException(nameof(nameValues));
 
             nameValues.Set(CommonConstants.QUERYSTRING_CULTURE_KEY,
                 Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName.StartsWith(CommonConstants.ENGLISH_CULTURE_TWO_LETTER,

--- a/GCDS.NetTemplate/Core/Initializer.cs
+++ b/GCDS.NetTemplate/Core/Initializer.cs
@@ -36,8 +36,8 @@ namespace GCDS.NetTemplate.Core
             var template = Activator.CreateInstance(templateType, _settings) as ITemplateBase 
                 ?? throw new InvalidOperationException($"Cannot create instance of {templateType}");
 
-            template.LanguageToggleHref = CultureManager.BuildLanguageToggleHref(
-                HttpUtility.ParseQueryString(context.Request.QueryString.ToString()));
+            template.SetLanguageToggleHref(CultureManager.BuildLanguageToggleHref(
+                HttpUtility.ParseQueryString(context.Request.QueryString.ToString())));
 
             viewData[CommonConstants.TEMPLATE_DATA] = template;
         }

--- a/GCDS.NetTemplate/Templates/Basic.cs
+++ b/GCDS.NetTemplate/Templates/Basic.cs
@@ -1,4 +1,5 @@
 ﻿using GCDS.NetTemplate.Components;
+using GCDS.NetTemplate.Core;
 using System.Reflection;
 
 namespace GCDS.NetTemplate.Templates
@@ -10,6 +11,7 @@ namespace GCDS.NetTemplate.Templates
         /// </summary>
         public GcdsHeader Header { get; } = new GcdsHeader()
         {
+            SkipToHref = $"#{CommonConstants.SKIP_TO_CONTENT_ID}",
             Search = new GcdsSearch(),
             Breadcrumb = new GcdsBreadcrumbs()
         };
@@ -31,5 +33,9 @@ namespace GCDS.NetTemplate.Templates
             // get the date changed of the project that started (impemented this package)
             Text = File.GetLastWriteTime(Assembly.GetEntryAssembly()?.Location ?? string.Empty).ToString("MMMM dd, yyyy")
         };
+
+        public override void SetLanguageToggleHref(string href)
+            => Header.LangHref = href ?? throw new ArgumentNullException(nameof(href));
+        
     };
 }

--- a/GCDS.NetTemplate/Templates/InternalApp.cs
+++ b/GCDS.NetTemplate/Templates/InternalApp.cs
@@ -33,18 +33,17 @@ namespace GCDS.NetTemplate.Templates
         public override void SetLanguageToggleHref(string href)
             => LangToggleHref = href ?? throw new ArgumentNullException(nameof(href));
 
-        public InternalApp Inizialize(string siteTitle, string pageTitle)
+        public InternalApp Inizialize(string siteTitle)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(siteTitle);
             return Inizialize(new ExtSiteTitle
             {
                 Text = siteTitle
-            }, pageTitle);
+            });
         }
-        public InternalApp Inizialize(ExtSiteTitle siteTitle, string pageTitle)
+        public InternalApp Inizialize(ExtSiteTitle siteTitle)
         {
             ArgumentNullException.ThrowIfNull(siteTitle);
-            PageTitle = pageTitle;
             Header = new ExtAppHeader {
                 AppHeaderTop = new ExtAppHeaderTop
                 {

--- a/GCDS.NetTemplate/Templates/InternalApp.cs
+++ b/GCDS.NetTemplate/Templates/InternalApp.cs
@@ -9,7 +9,7 @@ namespace GCDS.NetTemplate.Templates
         /// <summary>
         /// Loading all the configurations for the header component
         /// </summary>
-        public required ExtAppHeader Header { get; set; }
+        public ExtAppHeader? Header { get; set; }
 
         /// <summary>
         /// Loading all the configurations for the footer component
@@ -23,10 +23,36 @@ namespace GCDS.NetTemplate.Templates
         public GcdsDateModified DateModified { get; set; } = new GcdsDateModified()
         {
             // get the version number of the project that started (impemented this package) and trim any trailing zeros from the version
-            Text = string.Join(".", 
+            Text = string.Join(".",
                 (FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()?.Location ?? string.Empty).FileVersion ?? string.Empty)
                 .Split('.').Reverse().SkipWhile(s => s == "0").Reverse()),
             Type = GcdsDateModified.DateModifiedType.version
         };
+
+        public string LangToggleHref { get; set; } = "";
+        public override void SetLanguageToggleHref(string href)
+            => LangToggleHref = href ?? throw new ArgumentNullException(nameof(href));
+
+        public InternalApp Inizialize(string siteTitle, string pageTitle)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(siteTitle);
+            return Inizialize(new ExtSiteTitle
+            {
+                Text = siteTitle
+            }, pageTitle);
+        }
+        public InternalApp Inizialize(ExtSiteTitle siteTitle, string pageTitle)
+        {
+            ArgumentNullException.ThrowIfNull(siteTitle);
+            PageTitle = pageTitle;
+            Header = new ExtAppHeader {
+                AppHeaderTop = new ExtAppHeaderTop
+                {
+                    LanguageToggle = new GcdsLangToggle { Href = LangToggleHref },
+                    SiteTitle = siteTitle
+                }
+            };
+            return this;
+        }        
     }
 }

--- a/GCDS.NetTemplate/Templates/Splash.cs
+++ b/GCDS.NetTemplate/Templates/Splash.cs
@@ -47,5 +47,8 @@ namespace GCDS.NetTemplate.Templates
         {
             Type = GcdsSignature.SignatureType.wordmark
         };
+
+        // Do nothing, this layout doesn't use a toggle
+        public override void SetLanguageToggleHref(string href) { }
     }
 }

--- a/GCDS.NetTemplate/Templates/TemplateBase.cs
+++ b/GCDS.NetTemplate/Templates/TemplateBase.cs
@@ -6,16 +6,16 @@ namespace GCDS.NetTemplate.Templates
     {
         TemplateSettings Settings { get; set; }
 
-        string LanguageToggleHref { get; set; }
-
         string Lang { get; set; }
 
         string PageTitle { get; set; }
 
         List<ExtHtmlElement> HeadElements { get; set; }
+
+        void SetLanguageToggleHref(string href);
     }
 
-    public class TemplateBase(TemplateSettings settings)
+    public abstract class TemplateBase(TemplateSettings settings, string pageTitle = "") : ITemplateBase
     {
         /// <summary>
         /// Template settings, loaded from the appsettings.json file
@@ -23,26 +23,26 @@ namespace GCDS.NetTemplate.Templates
         public TemplateSettings Settings { get; set; } = settings;
 
         /// <summary>
-        /// Toogle link for the language
-        /// Set in the ActionFilter
-        /// Passt to Header element, stored here for customization
-        /// </summary>
-        public required string LanguageToggleHref { get; set; }
-
-        /// <summary>
         /// The CurrentUICulture to ensure the components load with the right language settings
         /// </summary>
-        public string Lang { get; set; } = Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
+        public string Lang { get; set; }
+         = Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
 
         /// <summary>
         /// title of page
         /// </summary>
-        public string PageTitle { get; set; } = string.Empty;
+        public string PageTitle { get; set; } = pageTitle;
 
         /// <summary>
         /// Creates a list of HeadElements that will be added to the head of the page.
         /// Used for adding meta tags, linking to styles or scripts.
         /// </summary>
         public List<ExtHtmlElement> HeadElements { get; set; } = [];
+
+        /// <summary>
+        /// Enables settign the toogle link for the language
+        /// Set in the ActionFilter by default
+        /// </summary>
+        public abstract void SetLanguageToggleHref(string href);
     }
 }

--- a/GCDS.NetTemplate/Templates/TemplateExtensions.cs
+++ b/GCDS.NetTemplate/Templates/TemplateExtensions.cs
@@ -5,8 +5,15 @@ namespace GCDS.NetTemplate.Templates
 {
     public static class TemplateExtensions
     {
-        public static ITemplateBase? GetITemplate(this ViewDataDictionary viewData, string key = CommonConstants.TEMPLATE_DATA) => viewData[key] as ITemplateBase;
+        public static TemplateBase? GetTemplateBase(
+            this ViewDataDictionary viewData, 
+            string key = CommonConstants.TEMPLATE_DATA) 
+            => viewData[key] as TemplateBase;
 
-        public static T? GetTemplate<T>(this ViewDataDictionary viewData, string key = CommonConstants.TEMPLATE_DATA) where T : class, ITemplateBase => viewData[key] as T;        
+        public static T? GetTemplate<T>(
+            this ViewDataDictionary viewData, 
+            string key = CommonConstants.TEMPLATE_DATA) 
+            where T : class, ITemplateBase 
+            => viewData[key] as T;        
     }
 }

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
@@ -1,9 +1,9 @@
 ﻿@using GCDS.NetTemplate.Templates
+@using GCDS.NetTemplate.Core
 
 @{
-    var template = ViewData.GetITemplate();
-	ArgumentNullException.ThrowIfNull(template, 
-        "Must call Add[Mvc]TemplateServices in Program.cs, and verify the template is loaded to the ViewData to use this layout.");
+    var template = ViewData.GetTemplateBase();
+	ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
 }
 
 <!DOCTYPE html>
@@ -17,12 +17,11 @@
     {
         @await Html.PartialAsync("ExtHtmlElement.cshtml", headElement)
     }
-    @await RenderSectionAsync("Head", required: false)
+	@await RenderSectionAsync("LayoutHead", required: false)
+    @await RenderSectionAsync("PageHead", required: false)
 </head>
 <body>
-    @RenderSection("Header", required: false)
-    @RenderSection("MainContent", required: true)
-    @RenderSection("Footer", required: false)
-    @await RenderSectionAsync("Scripts", required: false)
+    @await RenderSectionAsync("LayoutBody", required: true)
+    @await RenderSectionAsync("PageScripts", required: false)
 </body>
 </html>

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
@@ -1,0 +1,28 @@
+﻿@using GCDS.NetTemplate.Templates
+
+@{
+    var template = ViewData.GetITemplate();
+	ArgumentNullException.ThrowIfNull(template, 
+        "Must call Add[Mvc]TemplateServices in Program.cs, and verify the template is loaded to the ViewData to use this layout.");
+}
+
+<!DOCTYPE html>
+<html lang="@template.Lang">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@template.PageTitle</title>
+    @await Html.PartialAsync("ExtHeadSettings.cshtml", template.Settings)
+    @foreach (var headElement in template.HeadElements)
+    {
+        @await Html.PartialAsync("ExtHtmlElement.cshtml", headElement)
+    }
+    @await RenderSectionAsync("Head", required: false)
+</head>
+<body>
+    @RenderSection("Header", required: false)
+    @RenderSection("MainContent", required: true)
+    @RenderSection("Footer", required: false)
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Basic.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Basic.cshtml
@@ -4,31 +4,22 @@
 
 @{
 	Basic? template = ViewData.GetTemplate<Basic>();
-	ArgumentNullException.ThrowIfNull(template, 
-		"Must call Add[Mvc]TemplateServices in Program,cs, and verify the BasicTemplate (Default) is loaded to the ViewData to use this layout.");
-	Layout = "_Layout.Base.cshtml"; // Use the base layout for this template"
+	ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
+	Layout = "_Layout.Base.cshtml"; // Use the base layout for this template
 }
 
-@section Header {
+@section LayoutBody {
 	<header>
-		@{
-			template.Header.LangHref = template.LanguageToggleHref;
-			template.Header.SkipToHref = "#" + CommonConstants.SKIP_TO_CONTENT_ID;
-		}
 		@await Html.PartialAsync("GcdsHeader.cshtml", template.Header)
 	</header>
-}
-	
-@section MainContent {
-	<gcds-container size="xl" centered mmmonCoain-container>
+
+	<gcds-container size="xl" centered main-container>
 		<main id="@CommonConstants.SKIP_TO_CONTENT_ID" role="main">
 			@RenderBody()
 		</main>
 
 		@await Html.PartialAsync("GcdsDateModified.cshtml", template.DateModified)
 	</gcds-container>
-}
 
-@section Footer {
 	@await Html.PartialAsync("GcdsFooter.cshtml", template.Footer)
 }

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Basic.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Basic.cshtml
@@ -4,24 +4,12 @@
 
 @{
 	Basic? template = ViewData.GetTemplate<Basic>();
-	ArgumentNullException.ThrowIfNull(template, "Must call Add[Mvc]TemplateServices in Program,cs, and verify the BasicTemplate (Default) is loaded to the ViewData to use this layout.");
+	ArgumentNullException.ThrowIfNull(template, 
+		"Must call Add[Mvc]TemplateServices in Program,cs, and verify the BasicTemplate (Default) is loaded to the ViewData to use this layout.");
+	Layout = "_Layout.Base.cshtml"; // Use the base layout for this template"
 }
 
-<!DOCTYPE html>
-<html lang="@template.Lang">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>@template.PageTitle</title>
-
-	@await Html.PartialAsync("ExtHeadSettings.cshtml", template.Settings)
-	@foreach (var headElement in template.HeadElements)
-	{
-		@await Html.PartialAsync("ExtHtmlElement.cshtml", headElement)
-	}
-	@await RenderSectionAsync("Head", required: false)
-</head>
-<body>
+@section Header {
 	<header>
 		@{
 			template.Header.LangHref = template.LanguageToggleHref;
@@ -29,7 +17,9 @@
 		}
 		@await Html.PartialAsync("GcdsHeader.cshtml", template.Header)
 	</header>
-
+}
+	
+@section MainContent {
 	<gcds-container size="xl" centered mmmonCoain-container>
 		<main id="@CommonConstants.SKIP_TO_CONTENT_ID" role="main">
 			@RenderBody()
@@ -37,9 +27,8 @@
 
 		@await Html.PartialAsync("GcdsDateModified.cshtml", template.DateModified)
 	</gcds-container>
+}
 
+@section Footer {
 	@await Html.PartialAsync("GcdsFooter.cshtml", template.Footer)
-
-	@await RenderSectionAsync("Scripts", required: false)
-</body>
-</html>
+}

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.InternalApp.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.InternalApp.cshtml
@@ -4,37 +4,19 @@
 
 @{
 	InternalApp? template = ViewData.GetTemplate<InternalApp>();
-	ArgumentNullException.ThrowIfNull(template, "Must call Add[Mvc]TemplateServices in Program,cs, and verify the InternalAppTemplate is loaded to the ViewData to use this layout.");
+	ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
+	Layout = "_Layout.Base.cshtml"; // Use the base layout for this template
 }
 
-<!DOCTYPE html>
-<html lang="@template.Lang">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport"
-		  content="width=device-width, initial-scale=1.0" />
-
-	<title>@template.PageTitle</title>
-
-	@await Html.PartialAsync("ExtHeadSettings.cshtml", template.Settings)
-	@foreach (var headElement in template.HeadElements)
-	{
-		@await Html.PartialAsync("ExtHtmlElement.cshtml", headElement)
-	}
-	@await RenderSectionAsync("Head", required: false)
-</head>
-<body>
+@section LayoutBody {
 	@{
-		ArgumentNullException.ThrowIfNull(template.Header, "Header must be set when using this template.");
-		template.Header.AppHeaderTop.LanguageToggle.Href = template.LanguageToggleHref;
+		ArgumentNullException.ThrowIfNull(template.Header, 
+			"Header must be set when using this template.");
 	}
 	@await Html.PartialAsync("ExtAppHeader.cshtml", template.Header)
 
-	<gcds-container size="xl"
-					centered
-					main-container>
-		<main id="@CommonConstants.SKIP_TO_CONTENT_ID"
-			  role="main">
+	<gcds-container size="xl" centered main-container>
+		<main id="@CommonConstants.SKIP_TO_CONTENT_ID" role="main">
 			@RenderBody()
 		</main>
 
@@ -42,7 +24,4 @@
 	</gcds-container>
 
 	@await Html.PartialAsync("GcdsFooter.cshtml", template.Footer)
-
-	@await RenderSectionAsync("Scripts", required: false)
-</body>
-</html>
+}

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Splash.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Splash.cshtml
@@ -5,25 +5,11 @@
 
 @{
 	Splash? template = ViewData.GetTemplate<Splash>();
-	ArgumentNullException.ThrowIfNull(template, "Must call Add[Mvc]TemplateServices in Program,cs, and verify the SplashTemplate is loaded to the ViewData to use this layout.");
+	ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
+	Layout = "_Layout.Base.cshtml"; // Use the base layout for this template
 }
 
-<!DOCTYPE html>
-<html lang="@template.Lang">
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport"
-		  content="width=device-width, initial-scale=1.0" />
-
-	<title>@template.PageTitle</title>
-
-	@await Html.PartialAsync("ExtHeadSettings.cshtml", template.Settings)
-	@foreach (var headElement in template.HeadElements)
-	{
-		@await Html.PartialAsync("ExtHtmlElement.cshtml", headElement)
-	}
-	@await RenderSectionAsync("Head", required: false)
-
+@section LayoutHead {
 	<style>
 		#splash-window-top {
 			padding: 1rem 2.5rem 3rem;
@@ -76,10 +62,9 @@
 			font: var(--gcds-font-h6);
 		}
 	</style>
-</head>
+}
 
-<body>
-
+@section LayoutBody {
 	@await Html.PartialAsync("ExtRandomBackground.cshtml", template.SplashImages)
 
 	<main>
@@ -89,7 +74,8 @@
 				@await Html.PartialAsync("GcdsSignature.cshtml", template.TopSignature)
 
 				@{
-					ArgumentNullException.ThrowIfNull(template.LanguageSelector, "LanguageSelector must be set when using this template.");
+					ArgumentNullException.ThrowIfNull(template.LanguageSelector, 
+						"LanguageSelector must be set when using this template.");
 				}
 				@await Html.PartialAsync("ExtLanguageSelector.cshtml", template.LanguageSelector)
 			</div>
@@ -100,7 +86,7 @@
 							var enTerms = new HtmlString($@"<li><a href='{template.TermsEn.Href}' lang='en'>{template.TermsEn.Text}</a></li>");
 							var frTerms = new HtmlString($@"<li><a href='{template.TermsFr.Href}' lang='fr'>{template.TermsFr.Text}</a></li>");
 						}
-mmonCo
+
 						@if (template.Lang == CommonConstants.ENGLISH_CULTURE_TWO_LETTER)
 						{
 							@enTerms
@@ -117,8 +103,4 @@ mmonCo
 		</gcds-container>
 		@RenderBody()
 	</main>
-	
-	@await RenderSectionAsync("Scripts", required: false)
-</body>
-
-</html>
+}

--- a/README.md
+++ b/README.md
@@ -96,22 +96,28 @@ _Note: `Head` and `Script` sections are also avaliable on all templates._
 
 #### Using InternalApp Template
 
-This template will require you to manually create the `Header` as it requires you to set `SiteTitle` link text. The object initializer can be used or use the convient constructors.
+It's recommended to use the `Inizialize` function on this template to set the required properties. This function is chainable to access other properties.
 
 ```csharp
-template.Header = new ExtAppHeader("My Application");
+template.Inizialize("My Application Title");
 // OR
-template.Header = new ExtAppHeader(new ExtSiteTitle { Text = "Home", Href = "#" });
-// OR
+template.Inizialize(new ExtSiteTitle { Text = "Home", Href = "#" })
+    .HeadElements.AddMeta("name", "content");
+```
+
+You can still self initialize the required props. When doing so you can access the `LangToggleHref` built by the template instaed of creating that yourself.
+
+```csharp
 template.Header = new ExtAppHeader
 {
     AppHeaderTop = new ExtAppHeaderTop
     {
+        LanguageToggle = new GcdsLangToggle { Href = template.LangToggleHref },
         SiteTitle = new ExtSiteTitle
         {
-            Text = "My Application",
+            Text = "My Very Long Application Title That fills the whole header",
             Href = Url.Action("Index")
-        }
+        },
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ template.Header = new ExtAppHeader
         LanguageToggle = new GcdsLangToggle { Href = template.LangToggleHref },
         SiteTitle = new ExtSiteTitle
         {
-            Text = "My Very Long Application Title That fills the whole header",
+            Text = "My Application",
             Href = Url.Action("Index")
         },
     }


### PR DESCRIPTION
- Using the TemplateBase to create a _Layout.Base to use across all layouts.
- Refining how props are set, like (LangToggle, and SkipHerf) to set within the template initialization code base, not the layout.
- Providing cleaner initialization of ExtInternalApp

resolves #31 