### PR TITLE
Adding dynamic viewdata options for breadcrumbs and page title

### DIFF
--- a/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
+++ b/GCDS.NetTemplate.MVC.Sanity/Controllers/HomeController.cs
@@ -76,6 +76,7 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
             // OR
             template.Initialize("Internal Page", new ExtSiteTitle { Text = "Home", Href = "#" })
                 .HeadElements.AddMeta("name", "content");
+            
             // OR
             template.Header = new ExtAppHeader
             {
@@ -119,6 +120,9 @@ namespace GCDS.NetTemplate.MVC.Sanity.Controllers
                         ]
                 }
             };
+
+            template.PageTitleAction = TemplateBase.ViewDataAction.Append;
+            template.Header.Breadcrumbs.ItemsAction = TemplateBase.ViewDataAction.Prepend;
             //template.Footer.StyleOverride = "border-top: 4px solid #243851; background: #f8f8f8;";
 
             return View();

--- a/GCDS.NetTemplate.MVC.Sanity/Views/Home/Home.cshtml
+++ b/GCDS.NetTemplate.MVC.Sanity/Views/Home/Home.cshtml
@@ -1,6 +1,4 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
-}
+﻿@using GCDS.NetTemplate.Components
 
 <h1>Welcome</h1>
 <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>

--- a/GCDS.NetTemplate.MVC.Sanity/Views/Home/Internal.cshtml
+++ b/GCDS.NetTemplate.MVC.Sanity/Views/Home/Internal.cshtml
@@ -1,6 +1,12 @@
-﻿@{
+﻿@using GCDS.NetTemplate.Components
+@{
     Layout = "GCDS.NetTemplate/_Layout.InternalApp";
     ViewData["PageIdentifier"] = "CESG4010F";
+
+    ViewBag.PageTitle = "Home Page"; // could use a localizer here
+    ViewBag.Breadcrumbs = new List<GcdsLink> {
+        new("#", "Go back") // can use a Url.Action here
+    };
 }
 
 <h1>Hello!</h1>

--- a/GCDS.NetTemplate/Components/GcdsBreadcrumbs.cs
+++ b/GCDS.NetTemplate/Components/GcdsBreadcrumbs.cs
@@ -1,4 +1,6 @@
-﻿namespace GCDS.NetTemplate.Components
+﻿using static GCDS.NetTemplate.Templates.TemplateBase;
+
+namespace GCDS.NetTemplate.Components
 {
     /// <summary>
     /// Class holder for the breadcrumb properties as defined in the GCDS template
@@ -15,5 +17,7 @@
         /// List of links to be displayed in the breadcrumbs
         /// </summary>
         public IEnumerable<GcdsLink>? Items { get; set; }
+
+        public ViewDataAction ItemsAction { get; set; } = ViewDataAction.Replace;
     }
 }

--- a/GCDS.NetTemplate/Templates/TemplateBase.cs
+++ b/GCDS.NetTemplate/Templates/TemplateBase.cs
@@ -40,6 +40,10 @@ namespace GCDS.NetTemplate.Templates
         /// </summary>
         public string PageTitle { get; set; } = null!;
 
+        public enum ViewDataAction { Replace, Prepend, Append }
+
+        public ViewDataAction PageTitleAction { get; set; } = ViewDataAction.Replace;
+
         /// <summary>
         /// Creates a list of HeadElements that will be added to the head of the page.
         /// Used for adding meta tags, linking to styles or scripts.

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsBreadcrumbs.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/GcdsBreadcrumbs.cshtml
@@ -1,10 +1,24 @@
 ﻿@using GCDS.NetTemplate.Components
+@using static GCDS.NetTemplate.Templates.TemplateBase
 
 @model GcdsBreadcrumbs
 
+@{
+	if(ViewData["Breadcrumbs"] is IEnumerable<GcdsLink> gcdsLinks)
+	{
+		Model.Items = Model.Items == null || Model.Items.Count() <= 0
+			? gcdsLinks
+			: Model.ItemsAction switch
+			{
+				ViewDataAction.Prepend => gcdsLinks.Concat(Model.Items),
+				ViewDataAction.Append => Model.Items.Concat(gcdsLinks),
+				_ => gcdsLinks
+			};
+	}
+}
+
 <gcds-breadcrumbs hide-canada-link="@Model.HideCanadaLink"
 				  lang="@Model.Lang" slot="@Model.Slot">
-
 	@if (Model.Items != null)
 	{
 		foreach (var item in Model.Items)

--- a/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
+++ b/GCDS.NetTemplate/Views/Shared/GCDS.NetTemplate/_Layout.Base.cshtml
@@ -3,7 +3,20 @@
 
 @{
     var template = ViewData.GetTemplateBase();
-	ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
+    ArgumentNullException.ThrowIfNull(template, CommonConstants.ERRMSG_LOAD_TEMPLATE);
+
+    var pageTitle = ViewData["PageTitle"] as string;
+    if (!string.IsNullOrEmpty(pageTitle))
+    {
+        template.PageTitle = string.IsNullOrEmpty(template.PageTitle)
+            ? pageTitle
+            : template.PageTitleAction switch
+            {
+                TemplateBase.ViewDataAction.Prepend => $"{pageTitle} - {template.PageTitle}",
+                TemplateBase.ViewDataAction.Append => $"{template.PageTitle} - {pageTitle}",
+                _ => pageTitle
+            };
+    }
 }
 
 <!DOCTYPE html>

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ var template = ViewData.GetTemplate<InternalApp>();
 template.Inizialize(...)
 ```
 
+#### Adding Head data
+ 
 Since most sites work better with meta data, be sure to add some through the `HeadElements`. You can also add links to scripts and style pages, or any kind of head element you wish.
 
 ```csharp
@@ -88,6 +90,25 @@ template.HeadElements.AddCustom("tag", new Dictionary<string, string> { { "tagAt
 ```
 
 _Note: `Head` and `Script` sections are also avaliable on all templates._
+
+#### Dynamic ViewData
+
+There are currently 2 dynamic ViewData attributes `Breadcrumbs` and `PageTitle`.
+They are configured inside anwhere you can access the ViewData or ViewBag.
+```cshtml
+ViewBag.PageTitle = "Home Page"; // should use a localizer here
+ViewBag.Breadcrumbs = new List<GcdsLink> {
+    new("#", "Go back") // should use a Url.Action here
+};
+```
+
+How they are used can also be modified with the following attributes: (the default is "Replace")
+```csharp
+public enum ViewDataAction { Replace, Prepend, Append }
+template.PageTitleAction = TemplateBase.ViewDataAction.Append;
+template.Header.Breadcrumbs.ItemsAction = TemplateBase.ViewDataAction.Prepend;
+```
+
 
 #### Using InternalApp Template
 


### PR DESCRIPTION
<!-- Please describe what your pr is tring to do in detail -->
Accepting a ViewData element for Breadcrumbs and PageTitle that will enable the user to pass information at the view level using a localizer if they choose. They can also configure how that element is treated with any existing values from the template.

<!-- Identify what issue this PR addresses -->
Fixes # INTERNAL

## Code Change Checks
_All PRs making changes to code should also ensure the following are also included in the PR._
- [x] Sample code added to MVC.Sanity
- [ ] Sample code added to Razor.Sanity
- [ ] Automated tests added to validate the accessibility
- [x] Documentation updated (in README)
